### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -11,11 +11,11 @@
 # Methods and Functions (KEYWORD2)
 #######################################
 
-DBEGIN	 KEYWORD2
-DPRINT	 KEYWORD2
-DPRINTLN	 KEYWORD2
-DPRINTF	 KEYWORD2
-DPRINTFLN	 KEYWORD2
+DBEGIN	KEYWORD2
+DPRINT	KEYWORD2
+DPRINTLN	KEYWORD2
+DPRINTF	KEYWORD2
+DPRINTFLN	KEYWORD2
 
 
 #######################################
@@ -26,4 +26,4 @@ DPRINTFLN	 KEYWORD2
 #######################################
 # Constants (LITERAL1)
 #######################################
-DEBUG_SKETCH  LITERAL1
+DEBUG_SKETCH	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords